### PR TITLE
Allow a dot in the route

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -77,7 +77,7 @@ return array(
                             ),
                             'constraints' => array(
                                 'article' => '[0-9]+',
-                                'slug'    => '[a-zA-Z0-9-_]+',
+                                'slug'    => '[a-zA-Z0-9-_.]+',
                             ),
                         ),
                     ),


### PR DESCRIPTION
Dots are never part of the slug, but if any URI is hit with a dot
in the URI, the controller will now redirect it to the proper link
instead of returning a 404 Not Found.
