### PR TITLE
Hook into ensemble to add navigation properties

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -87,7 +87,7 @@ class Module implements
 
         $this->attachTemplateListener($em);
         $this->attachFeedStrategy($em, $sm);
-        $this->attachNavigationMetadata($em);
+        $this->attachNavigationMetadata($em, $sm);
     }
 
     protected function attachTemplateListener($em)
@@ -113,11 +113,21 @@ class Module implements
         }, 10);
     }
 
-    protected function attachNavigationMetadata($em)
+    protected function attachNavigationMetadata($em, $sm)
     {
-        $em->attach('Ensemble\Kernel\Parser\Navigation', 'parsePage.blog', function($e) {
+        $em->attach('Ensemble\Kernel\Parser\Navigation', 'parsePage.blog', function($e) use ($sm) {
+            $config  = $sm->get('Config');
+            $options = $config['soflomo_blog']['sitemap'];
+
             $page = $e->getParam('navigation');
-            $page->set('changefreq', 'hourly');
+
+            if (null !== $options['changefreq']) {
+                $page->set('changefreq', $options['changefreq']);
+            }
+
+            if (null !== $options['priority']) {
+                $page->set('priority', $options['priority']);
+            }
         });
     }
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -50,6 +50,11 @@ return array(
         'feed_listing_limit'    => 10,
         'admin_listing_limit'   => 10,
 
+        'sitemap'               => array(
+            'changefreq' => '',
+            'priority'   => '',
+        ),
+
         'feed_generator'        => array(
             'name'    => 'Ensemble blog',
             'version' => 'v0.1.0',


### PR DESCRIPTION
The changefreq and priority of the page in the ensemble navigation will be updated based on the configuration options provided.

To get this working:
1. Load the latest ensemble kernel ([72a45f0](https://github.com/ensemble/EnsembleKernel/commit/72a45f078f3c27cc1ac543f20cbed8e41996b27f) must be incorporated)
2. Add this to the config:

``` php
'soflomo_blog' => array(
    'sitemap' => array(
        'changefreq' => 'hourly',
        'priority'   => '0.8',
    ),
),
```

This results in the XML sitemap to be generated with these child nodes:

``` xml
<url>
  <loc>http://example.com/blog</loc>
  <changefreq>hourly</changefreq>
  <priority>0.8</priority>
</url>
```
